### PR TITLE
Performance increase to shadowText.gml

### DIFF
--- a/scripts/shadowText.gml
+++ b/scripts/shadowText.gml
@@ -9,42 +9,27 @@ var textX = argument0,
     sColor = argument4,
     sDist = argument5;
 
-//set the draw color to the shadow color
-draw_set_colour(sColor)
-
 //draw the shadow at the apropriate distance (it greatly varies depending on your game size ratio)
-draw_text(textX + sDist, textY + sDist, text)
-
-//set the text color
-draw_set_colour(tColor)
+draw_text_colour(textX + sDist, textY + sDist, text, sColor, sColor, sColor, sColor, 1);
 
 //draw the actual text
-draw_text(textX, textY, text)
+draw_text_colour(textX, textY, text, tColor, tColor, tColor, tColor, 1);
 
 #define shadowTextSimple
 ///shadowTextSimple(x, y, text)
 //draw the text with the minimum variables as possible
-
-var textX = argument0;
-var textY = argument1;
-var text = argument2;
-
-shadowText(textX, textY, text, c_white, c_black, 1)
+gml_pragma("forceinline");
+shadowText(argument0, argument1, argument2, c_white, c_black, 1);
 
 #define shadowTextColored
 ///shadowTextColored(x, y, text, color)
 //draw the text with color
-
-var textX = argument0;
-var textY = argument1;
-var text = argument2;
-var color = argument3;
-
-shadowText(textX, textY, text, color, c_black, 1,)
+gml_pragma("forceinline");
+shadowText(argument0, argument1, argument2, argument3, c_black, 1);
 
 #define shadowTextReset
 ///shadowTextReset()
 //reset the draw text variables
-draw_set_halign(fa_left)
-draw_set_valign(fa_top)
-draw_set_color(c_black)
+draw_set_halign(fa_left);
+draw_set_valign(fa_top);
+draw_set_color(c_black);


### PR DESCRIPTION
Your method of setting the colour and then drawing the text can be reduced down to using one function for each, which handles adjusting the colour, as well as removing the need to reset the colour after using the script.

Furthermore, I have reduced the override scripts down to just one line in order to make use of "gml_pragma("forceinline")", which is useful on scripts with one line of code, as it tells the compiler to insert the code rather than reference it (providing a slight performance boost).